### PR TITLE
Added support for multiple code languages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.5.3
+Removed the need to add comment characters in the settings for the beginning and end of foldable regions.
+Added code to retrieve current grammars comment style to allow for language agnostic region comments.
+Added .text selector to stylesheet to enable colorization on html files.
+
 ## 1.5.2
 Find-in-Files works again when 'auto fold on file load' is enabled. Yeah, that was a bad bug.
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This plugin was inspired by Visual Studio's treatment of C#'s `#region` tags.
 
 In the plugin's settings, you can define custom text that identifies the start and end of a foldable section of code.
 
-By default, the text `// <editor-fold` identifies the start of a foldable region and `// </editor-fold>` marks the end of the region. These default settings were only chosen because the author works on a team where a few "special" engineers insist on using JetBrain's WebStorm IDE. These tags allow both sets of engineers (those using Atom and those using WebStorm) to have the same foldable regions of code.
+By default, the text `<editor-fold` identifies the start of a foldable region and `</editor-fold>` marks the end of the region. These default settings were only chosen because the author works on a team where a few "special" engineers insist on using JetBrain's WebStorm IDE. These tags allow both sets of engineers (those using Atom and those using WebStorm) to have the same foldable regions of code.
 
 But you don't need to be working with people that insist on using WebStorm. You can configure the starting and ending tags to whatever you want. This allows you to create your own, custom, collapsible regions.
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -11,16 +11,16 @@ var CustomFolds =
 		config: {
 			prefix: {
 				title: 'Beginning of foldable region',
-				description: 'The first line of the folding block must start with this string literal (not counting leading white space).',
+				description: 'The first line of the folding block must start with this string literal (not counting leading white space or comment characters).',
 				type: 'string',
-				default: '// <editor-fold',
+				default: '<editor-fold',
 				order: 1
 			},
 			postfix: {
 				title: 'End of foldable region',
-				description: 'The last line of the folding block must start with this string literal (not counting leading white space).',
+				description: 'The last line of the folding block must start with this string literal (not counting leading white space or comment characters).',
 				type: 'string',
-				default: '// </editor-fold>',
+				default: '</editor-fold>',
 				order: 2,
 			},
 			areRegionsFoldedOnLoad: {
@@ -59,6 +59,9 @@ var CustomFolds =
 					'custom-folds:unfold-here': CustomFolds.unfoldHere,
 					'custom-folds:toggle-fold': CustomFolds.toggleFold
 				}));
+
+			editor = atom.workspace.getActiveTextEditor();
+			CustomFolds.commentChars = atom.config.get('editor.commentStart', {scope: editor.getRootScopeDescriptor()})
 
 			CustomFolds.prefix = atom.config.get('custom-folds.prefix');
 			atom.config.onDidChange('custom-folds.prefix', (change) => {
@@ -110,15 +113,18 @@ var CustomFolds =
 		// <editor-fold> RESPONDERS ********************************************
 		foldTopLevel() {
 			let editor = atom.workspace.getActiveTextEditor();
+			CustomFolds.commentChars = atom.config.get('editor.commentStart', {scope: editor.getRootScopeDescriptor()})
 
 			for (let c=0, cLen=editor.getLineCount(); c<cLen; ++c) {
 				const line = editor.lineTextForBufferRow(c).trim();
 
-				if (line.startsWith(CustomFolds.prefix)) {
-					const endRow = CustomFolds._rowOfEndTag(editor, c);
-					if (c < endRow) {
-						CustomFolds._fold(editor, c, endRow);
-						c = endRow + 1;
+				if (editor.isBufferRowCommented(c)) {
+					if (line.replace(CustomFolds.commentChars,'').trim().startsWith(CustomFolds.prefix)) {
+						const endRow = CustomFolds._rowOfEndTag(editor, c);
+						if (c < endRow) {
+							CustomFolds._fold(editor, c, endRow);
+							c = endRow + 1;
+						}
 					}
 				}
 			}
@@ -126,18 +132,21 @@ var CustomFolds =
 
 		foldAll() {
 			let editor = atom.workspace.getActiveTextEditor();
+			CustomFolds.commentChars = atom.config.get('editor.commentStart', {scope: editor.getRootScopeDescriptor()})
 
 			let startPrefixStack = [];
 			for (let c=0, cLen=editor.getLineCount(); c<cLen; ++c) {
 				const line = editor.lineTextForBufferRow(c).trim();
-				if (line.startsWith(CustomFolds.prefix)) {
-					startPrefixStack.push(c);
-				} else if (line.startsWith(CustomFolds.postfix)) {
-					if (startPrefixStack.length) {
-						const startRow = startPrefixStack.pop();
-						CustomFolds._fold(editor, startRow, c);
-					} else {
-						atom.notifications.addWarning(`Extra closing fold tag found at line ${c + 1}.`);
+				if (editor.isBufferRowCommented(c)) {
+					if (line.replace(CustomFolds.commentChars,'').trim().startsWith(CustomFolds.prefix)) {
+						startPrefixStack.push(c);
+					} else if (line.replace(CustomFolds.commentChars,'').trim().startsWith(CustomFolds.postfix)) {
+						if (startPrefixStack.length) {
+							const startRow = startPrefixStack.pop();
+							CustomFolds._fold(editor, startRow, c);
+						} else {
+							atom.notifications.addWarning(`Extra closing fold tag found at line ${c + 1}.`);
+						}
 					}
 				}
 			}
@@ -149,12 +158,15 @@ var CustomFolds =
 
 		unfoldAll() {
 			let editor = atom.workspace.getActiveTextEditor();
+			CustomFolds.commentChars = atom.config.get('editor.commentStart', {scope: editor.getRootScopeDescriptor()})
 
 			for (let c=0, cLen=editor.getLineCount(); c<cLen; ++c) {
 				const line = editor.lineTextForBufferRow(c).trim();
 
-				if (line.startsWith(CustomFolds.prefix)) {
-					editor.unfoldBufferRow(c);
+				if (editor.isBufferRowCommented(c)) {
+					if (line.replace(CustomFolds.commentChars,'').trim().startsWith(CustomFolds.prefix)) {
+						editor.unfoldBufferRow(c);
+					}
 				}
 			}
 		},
@@ -162,27 +174,31 @@ var CustomFolds =
 		// TODO: do this for each cursor
 		foldHere() {
 			let editor = atom.workspace.getActiveTextEditor();
+			CustomFolds.commentChars = atom.config.get('editor.commentStart', {scope: editor.getRootScopeDescriptor()})
 			let row = editor.getCursorBufferPosition().row;
-
 			for (let row=editor.getCursorBufferPosition().row; row>=0; --row) {
 				const line = editor.lineTextForBufferRow(row).trim();
-				if (line.startsWith(CustomFolds.prefix)) {
-					const endRow = CustomFolds._rowOfEndTag(editor, row);
-					if (row < endRow) {
-						CustomFolds._fold(editor, row, endRow);
+				if (editor.isBufferRowCommented(row)) {
+					if (line.replace(CustomFolds.commentChars,'').trim().startsWith(CustomFolds.prefix)) {
+						const endRow = CustomFolds._rowOfEndTag(editor, row);
+						if (row < endRow) {
+							CustomFolds._fold(editor, row, endRow);
+						}
+						break;
 					}
-					break;
 				}
 			}
 		},
 
 		unfoldHere() {
 			let editor = atom.workspace.getActiveTextEditor();
+			CustomFolds.commentChars = atom.config.get('editor.commentStart', {scope: editor.getRootScopeDescriptor()})
 			editor.unfoldBufferRow(editor.getCursorBufferPosition().row);
 		},
 
 		toggleFold() {
 			let editor = atom.workspace.getActiveTextEditor();
+			CustomFolds.commentChars = atom.config.get('editor.commentStart', {scope: editor.getRootScopeDescriptor()})
 			const row = editor.getCursorBufferPosition().row;
 			if (editor.isFoldedAtBufferRow(row)) {
 				CustomFolds.unfoldHere();
@@ -208,11 +224,13 @@ var CustomFolds =
 			const cLen = editor.getLineCount();
 			for (; c<cLen; ++c) {
 				const line = editor.lineTextForBufferRow(c).trim();
-				if (line.startsWith(CustomFolds.prefix)) {
-					++startTagCount;
-				} else if (line.startsWith(CustomFolds.postfix)) {
-					if (--startTagCount === 0) {
-						break;
+				if (editor.isBufferRowCommented(c)) {
+					if (line.replace(CustomFolds.commentChars,'').trim().startsWith(CustomFolds.prefix)) {
+						++startTagCount;
+					} else if (line.replace(CustomFolds.commentChars,'').trim().startsWith(CustomFolds.postfix)) {
+						if (--startTagCount === 0) {
+							break;
+						}
 					}
 				}
 			}
@@ -230,7 +248,7 @@ var CustomFolds =
 			if (!editor.isAlive()) {
 				return;
 			}
-
+			CustomFolds.commentChars = atom.config.get('editor.commentStart', {scope: editor.getRootScopeDescriptor()})
 			let markers = CustomFolds.editorIdToMarkers[editor.id];
 			markers.forEach((m) => m.destroy());
 
@@ -242,10 +260,12 @@ var CustomFolds =
 				const line = editor.lineTextForBufferRow(c).trim();
 
 				let cls;
-				if (line.startsWith(CustomFolds.prefix)) {
-					cls = 'custom-folds-start';
-				} else if (line.startsWith(CustomFolds.postfix)) {
-					cls = 'custom-folds-stop';
+				if (editor.isBufferRowCommented(c)) {
+					if (line.replace(CustomFolds.commentChars,'').trim().startsWith(CustomFolds.prefix)) {
+						cls = 'custom-folds-start';
+					} else if (line.replace(CustomFolds.commentChars,'').trim().startsWith(CustomFolds.postfix)) {
+						cls = 'custom-folds-stop';
+					}
 				}
 
 				if (cls) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,284 +1,299 @@
-"use babel";
+'use babel';
 
-import {CompositeDisposable, Point, Range, TextBuffer, TextEditor} from 'atom';
+import {CompositeDisposable, Point, Range, TextEditor} from 'atom';
 
 // option to auto fold on file open
 // clickable region headers, perhaps using block content?
 var CustomFolds =
-	module.exports = {
-		subscriptions: null,
+module.exports = {
+  subscriptions: null,
 
-		config: {
-			prefix: {
-				title: 'Beginning of foldable region',
-				description: 'The first line of the folding block must start with this string literal (not counting leading white space or comment characters).',
-				type: 'string',
-				default: '<editor-fold',
-				order: 1
-			},
-			postfix: {
-				title: 'End of foldable region',
-				description: 'The last line of the folding block must start with this string literal (not counting leading white space or comment characters).',
-				type: 'string',
-				default: '</editor-fold>',
-				order: 2,
-			},
-			areRegionsFoldedOnLoad: {
-				title: 'Auto fold on file open?',
-				description: 'If checked, regions start in their folded state when a file is opened.',
-				type: 'boolean',
-				default: false,
-				order: 3
-			},
-			areRegionsHighlighted: {
-				title: 'Enable experimental region highlighting?',
-				description: 'If checked, the beginning and end of foldable regions are highlighted. Only works if tags are part of commented line.',
-				type: 'boolean',
-				default: true,
-				order: 4
-			}
-		},
+  config: {
+    prefix: {
+      title: 'Beginning of foldable region',
+      description: 'The first line of the folding block must start with this string literal (not counting leading white space or comment characters).',
+      type: 'string',
+      default: '<editor-fold',
+      order: 1
+    },
+    postfix: {
+      title: 'End of foldable region',
+      description: 'The last line of the folding block must start with this string literal (not counting leading white space or comment characters).',
+      type: 'string',
+      default: '</editor-fold>',
+      order: 2
+    },
+    areRegionsFoldedOnLoad: {
+      title: 'Auto fold on file open?',
+      description: 'If checked, regions start in their folded state when a file is opened.',
+      type: 'boolean',
+      default: false,
+      order: 3
+    },
+    areRegionsHighlighted: {
+      title: 'Enable experimental region highlighting?',
+      description: 'If checked, the beginning and end of foldable regions are highlighted. Only works if tags are part of commented line.',
+      type: 'boolean',
+      default: true,
+      order: 4
+    }
+  },
 
-		prefix: '',
-		postfix: '',
-		areRegionsFoldedOnLoad: false,
-		areRegionsHighlighted: true,
+  prefix: '',
+  postfix: '',
+  areRegionsFoldedOnLoad: false,
+  areRegionsHighlighted: true,
 
-		editors: [],
-		editorIdToMarkers: {},
+  editors: [],
+  editorIdToMarkers: {},
 
-		// <editor-fold> LIFE **************************************************
-		activate() {
-			this.subscriptions = new CompositeDisposable();
-			this.subscriptions.add(
-				atom.commands.add('atom-workspace', {
-					'custom-folds:fold-top-level': CustomFolds.foldTopLevel,
-					'custom-folds:fold-all': CustomFolds.foldAll,
-					'custom-folds:unfold-all': CustomFolds.unfoldAll,
-					'custom-folds:fold-here': CustomFolds.foldHere,
-					'custom-folds:unfold-here': CustomFolds.unfoldHere,
-					'custom-folds:toggle-fold': CustomFolds.toggleFold
-				}));
+  // <editor-fold> LIFE **************************************************
+  activate() {
+    this.subscriptions = new CompositeDisposable();
+    this.subscriptions.add(
+      atom.commands.add('atom-workspace', {
+        'custom-folds:fold-top-level': CustomFolds.foldTopLevel,
+        'custom-folds:fold-all': CustomFolds.foldAll,
+        'custom-folds:unfold-all': CustomFolds.unfoldAll,
+        'custom-folds:fold-here': CustomFolds.foldHere,
+        'custom-folds:unfold-here': CustomFolds.unfoldHere,
+        'custom-folds:toggle-fold': CustomFolds.toggleFold
+      }));
 
-			editor = atom.workspace.getActiveTextEditor();
-			CustomFolds.commentChars = atom.config.get('editor.commentStart', {scope: editor.getRootScopeDescriptor()})
+    let editor = atom.workspace.getActiveTextEditor();
+    if ( editor ) {
+      CustomFolds.commentChars = atom.config.get('editor.commentStart', {scope: editor.getRootScopeDescriptor()});
+    }
 
-			CustomFolds.prefix = atom.config.get('custom-folds.prefix');
-			atom.config.onDidChange('custom-folds.prefix', (change) => {
-				CustomFolds.prefix = change.newValue;
-				CustomFolds._updateHighlightsAcrossEditors();
-			});
+    CustomFolds.prefix = atom.config.get('custom-folds.prefix');
+    atom.config.onDidChange('custom-folds.prefix', (change) => {
+      CustomFolds.prefix = change.newValue;
+      CustomFolds._updateHighlightsAcrossEditors();
+    });
 
-			CustomFolds.postfix = atom.config.get('custom-folds.postfix');
-			atom.config.onDidChange('custom-folds.postfix', (change) => {
-				CustomFolds.postfix = change.newValue;
-				CustomFolds._updateHighlightsAcrossEditors();
-			});
+    CustomFolds.postfix = atom.config.get('custom-folds.postfix');
+    atom.config.onDidChange('custom-folds.postfix', (change) => {
+      CustomFolds.postfix = change.newValue;
+      CustomFolds._updateHighlightsAcrossEditors();
+    });
 
-			CustomFolds.areRegionsFoldedOnLoad = atom.config.get('custom-folds.areRegionsFoldedOnLoad');
-			atom.config.onDidChange('custom-folds.areRegionsFoldedOnLoad', (change) => {
-				CustomFolds.areRegionsFoldedOnLoad = change.newValue;
-			});
+    CustomFolds.areRegionsFoldedOnLoad = atom.config.get('custom-folds.areRegionsFoldedOnLoad');
+    atom.config.onDidChange('custom-folds.areRegionsFoldedOnLoad', (change) => {
+      CustomFolds.areRegionsFoldedOnLoad = change.newValue;
+    });
 
-			CustomFolds.areRegionsHighlighted = atom.config.get('custom-folds.areRegionsHighlighted');
-			atom.config.onDidChange('custom-folds.areRegionsHighlighted', (change) => {
-				CustomFolds.areRegionsHighlighted = change.newValue;
-				CustomFolds._updateHighlightsAcrossEditors();
-			});
+    CustomFolds.areRegionsHighlighted = atom.config.get('custom-folds.areRegionsHighlighted');
+    atom.config.onDidChange('custom-folds.areRegionsHighlighted', (change) => {
+      CustomFolds.areRegionsHighlighted = change.newValue;
+      CustomFolds._updateHighlightsAcrossEditors();
+    });
 
-			this.subscriptions.add(atom.workspace.observeTextEditors((editor) => {
-				CustomFolds.editors.push(editor);
-				CustomFolds.editorIdToMarkers[editor.id] = [];
+    this.subscriptions.add(atom.workspace.observeTextEditors((editor) => {
+      CustomFolds.editors.push(editor);
+      CustomFolds.editorIdToMarkers[editor.id] = [];
 
-				if (CustomFolds.areRegionsHighlighted) {
-					CustomFolds._updateHighlights(editor);
-				}
+      if (CustomFolds.areRegionsHighlighted) {
+        CustomFolds._updateHighlights(editor);
+      }
 
-				// It's easier just to always subscribe to this.
-				editor.onDidStopChanging(() => CustomFolds._updateHighlights(editor));
-			}));
+      // It's easier just to always subscribe to this.
+      editor.onDidStopChanging(() => CustomFolds._updateHighlights(editor));
+    }));
 
-			this.subscriptions.add(atom.workspace.onDidOpen((event) => {
-				if (CustomFolds.areRegionsFoldedOnLoad && event.item instanceof TextEditor) {
-					CustomFolds.foldAll();
-				}
-			}));
-		},
+    this.subscriptions.add(atom.workspace.onDidOpen((event) => {
+      if (CustomFolds.areRegionsFoldedOnLoad && event.item instanceof TextEditor) {
+        CustomFolds.foldAll();
+      }
+    }));
+  },
 
-		deactivate() {
-			this.subscriptions.dispose();
-		},
-		// </editor-fold> life
+  deactivate() {
+    this.subscriptions.dispose();
+  },
+  // </editor-fold> life
 
-		// <editor-fold> RESPONDERS ********************************************
-		foldTopLevel() {
-			let editor = atom.workspace.getActiveTextEditor();
-			CustomFolds.commentChars = atom.config.get('editor.commentStart', {scope: editor.getRootScopeDescriptor()})
+  // <editor-fold> RESPONDERS ********************************************
+  foldTopLevel() {
+    let editor = atom.workspace.getActiveTextEditor();
+    if ( editor ) {
+      CustomFolds.commentChars = atom.config.get('editor.commentStart', {scope: editor.getRootScopeDescriptor()});
+    }
 
-			for (let c=0, cLen=editor.getLineCount(); c<cLen; ++c) {
-				const line = editor.lineTextForBufferRow(c).trim();
+    for (let c=0, cLen=editor.getLineCount(); c<cLen; ++c) {
+      const line = editor.lineTextForBufferRow(c).trim();
 
-				if (editor.isBufferRowCommented(c)) {
-					if (line.replace(CustomFolds.commentChars,'').trim().startsWith(CustomFolds.prefix)) {
-						const endRow = CustomFolds._rowOfEndTag(editor, c);
-						if (c < endRow) {
-							CustomFolds._fold(editor, c, endRow);
-							c = endRow + 1;
-						}
-					}
-				}
-			}
-		},
+      if (editor.isBufferRowCommented(c)) {
+        if (line.replace(CustomFolds.commentChars,'').trim().startsWith(CustomFolds.prefix)) {
+          const endRow = CustomFolds._rowOfEndTag(editor, c);
+          if (c < endRow) {
+            CustomFolds._fold(editor, c, endRow);
+            c = endRow + 1;
+          }
+        }
+      }
+    }
+  },
 
-		foldAll() {
-			let editor = atom.workspace.getActiveTextEditor();
-			CustomFolds.commentChars = atom.config.get('editor.commentStart', {scope: editor.getRootScopeDescriptor()})
+  foldAll() {
+    let editor = atom.workspace.getActiveTextEditor();
+    if ( editor ) {
+      CustomFolds.commentChars = atom.config.get('editor.commentStart', {scope: editor.getRootScopeDescriptor()});
+    }
 
-			let startPrefixStack = [];
-			for (let c=0, cLen=editor.getLineCount(); c<cLen; ++c) {
-				const line = editor.lineTextForBufferRow(c).trim();
-				if (editor.isBufferRowCommented(c)) {
-					if (line.replace(CustomFolds.commentChars,'').trim().startsWith(CustomFolds.prefix)) {
-						startPrefixStack.push(c);
-					} else if (line.replace(CustomFolds.commentChars,'').trim().startsWith(CustomFolds.postfix)) {
-						if (startPrefixStack.length) {
-							const startRow = startPrefixStack.pop();
-							CustomFolds._fold(editor, startRow, c);
-						} else {
-							atom.notifications.addWarning(`Extra closing fold tag found at line ${c + 1}.`);
-						}
-					}
-				}
-			}
+    let startPrefixStack = [];
+    for (let c=0, cLen=editor.getLineCount(); c<cLen; ++c) {
+      const line = editor.lineTextForBufferRow(c).trim();
+      if (editor.isBufferRowCommented(c)) {
+        if (line.replace(CustomFolds.commentChars,'').trim().startsWith(CustomFolds.prefix)) {
+          startPrefixStack.push(c);
+        } else if (line.replace(CustomFolds.commentChars,'').trim().startsWith(CustomFolds.postfix)) {
+          if (startPrefixStack.length) {
+            const startRow = startPrefixStack.pop();
+            CustomFolds._fold(editor, startRow, c);
+          } else {
+            atom.notifications.addWarning(`Extra closing fold tag found at line ${c + 1}.`);
+          }
+        }
+      }
+    }
 
-			if (startPrefixStack.length) {
-				atom.notifications.addWarning(`Extra opening fold tag found at line ${startPrefixStack.pop() + 1}.`);
-			}
-		},
+    if (startPrefixStack.length) {
+      atom.notifications.addWarning(`Extra opening fold tag found at line ${startPrefixStack.pop() + 1}.`);
+    }
+  },
 
-		unfoldAll() {
-			let editor = atom.workspace.getActiveTextEditor();
-			CustomFolds.commentChars = atom.config.get('editor.commentStart', {scope: editor.getRootScopeDescriptor()})
+  unfoldAll() {
+    let editor = atom.workspace.getActiveTextEditor();
+    if ( editor ) {
+      CustomFolds.commentChars = atom.config.get('editor.commentStart', {scope: editor.getRootScopeDescriptor()});
+    }
 
-			for (let c=0, cLen=editor.getLineCount(); c<cLen; ++c) {
-				const line = editor.lineTextForBufferRow(c).trim();
+    for (let c=0, cLen=editor.getLineCount(); c<cLen; ++c) {
+      const line = editor.lineTextForBufferRow(c).trim();
 
-				if (editor.isBufferRowCommented(c)) {
-					if (line.replace(CustomFolds.commentChars,'').trim().startsWith(CustomFolds.prefix)) {
-						editor.unfoldBufferRow(c);
-					}
-				}
-			}
-		},
+      if (editor.isBufferRowCommented(c)) {
+        if (line.replace(CustomFolds.commentChars,'').trim().startsWith(CustomFolds.prefix)) {
+          editor.unfoldBufferRow(c);
+        }
+      }
+    }
+  },
 
-		// TODO: do this for each cursor
-		foldHere() {
-			let editor = atom.workspace.getActiveTextEditor();
-			CustomFolds.commentChars = atom.config.get('editor.commentStart', {scope: editor.getRootScopeDescriptor()})
-			let row = editor.getCursorBufferPosition().row;
-			for (let row=editor.getCursorBufferPosition().row; row>=0; --row) {
-				const line = editor.lineTextForBufferRow(row).trim();
-				if (editor.isBufferRowCommented(row)) {
-					if (line.replace(CustomFolds.commentChars,'').trim().startsWith(CustomFolds.prefix)) {
-						const endRow = CustomFolds._rowOfEndTag(editor, row);
-						if (row < endRow) {
-							CustomFolds._fold(editor, row, endRow);
-						}
-						break;
-					}
-				}
-			}
-		},
+  // TODO: do this for each cursor
+  foldHere() {
+    let editor = atom.workspace.getActiveTextEditor();
+    if ( editor ) {
+      CustomFolds.commentChars = atom.config.get('editor.commentStart', {scope: editor.getRootScopeDescriptor()});
+    }
+    // let row = editor.getCursorBufferPosition().row;
+    for (let row=editor.getCursorBufferPosition().row; row>=0; --row) {
+      const line = editor.lineTextForBufferRow(row).trim();
+      if (editor.isBufferRowCommented(row)) {
+        if (line.replace(CustomFolds.commentChars,'').trim().startsWith(CustomFolds.prefix)) {
+          const endRow = CustomFolds._rowOfEndTag(editor, row);
+          if (row < endRow) {
+            CustomFolds._fold(editor, row, endRow);
+          }
+          break;
+        }
+      }
+    }
+  },
 
-		unfoldHere() {
-			let editor = atom.workspace.getActiveTextEditor();
-			CustomFolds.commentChars = atom.config.get('editor.commentStart', {scope: editor.getRootScopeDescriptor()})
-			editor.unfoldBufferRow(editor.getCursorBufferPosition().row);
-		},
+  unfoldHere() {
+    let editor = atom.workspace.getActiveTextEditor();
+    if ( editor ) {
+      CustomFolds.commentChars = atom.config.get('editor.commentStart', {scope: editor.getRootScopeDescriptor()});
+    }
+    editor.unfoldBufferRow(editor.getCursorBufferPosition().row);
+  },
 
-		toggleFold() {
-			let editor = atom.workspace.getActiveTextEditor();
-			CustomFolds.commentChars = atom.config.get('editor.commentStart', {scope: editor.getRootScopeDescriptor()})
-			const row = editor.getCursorBufferPosition().row;
-			if (editor.isFoldedAtBufferRow(row)) {
-				CustomFolds.unfoldHere();
-			} else {
-				CustomFolds.foldHere();
-			}
-		},
-		// </editor-fold> responders
+  toggleFold() {
+    let editor = atom.workspace.getActiveTextEditor();
+    if ( editor ) {
+      CustomFolds.commentChars = atom.config.get('editor.commentStart', {scope: editor.getRootScopeDescriptor()});
+    }
+    const row = editor.getCursorBufferPosition().row;
+    if (editor.isFoldedAtBufferRow(row)) {
+      CustomFolds.unfoldHere();
+    } else {
+      CustomFolds.foldHere();
+    }
+  },
+  // </editor-fold> responders
 
-		// <editor-fold> HELPERS ***********************************************
-		_fold(editor, startRow, endRow) {
-			editor.setSelectedBufferRange(new Range(new Point(startRow, 0), new Point(endRow, 0)));
-			editor.foldSelectedLines();
-			editor.moveUp();
-		},
+  // <editor-fold> HELPERS ***********************************************
+  _fold(editor, startRow, endRow) {
+    editor.setSelectedBufferRange(new Range(new Point(startRow, 0), new Point(endRow, 0)));
+    editor.foldSelectedLines();
+    editor.moveUp();
+  },
 
-		// takes nesting into account
-		_rowOfEndTag(editor, startRow) {
-			let result = -1;
+  // takes nesting into account
+  _rowOfEndTag(editor, startRow) {
+    let result = -1;
 
-			let startTagCount = 1;
-			let c = startRow + 1;
-			const cLen = editor.getLineCount();
-			for (; c<cLen; ++c) {
-				const line = editor.lineTextForBufferRow(c).trim();
-				if (editor.isBufferRowCommented(c)) {
-					if (line.replace(CustomFolds.commentChars,'').trim().startsWith(CustomFolds.prefix)) {
-						++startTagCount;
-					} else if (line.replace(CustomFolds.commentChars,'').trim().startsWith(CustomFolds.postfix)) {
-						if (--startTagCount === 0) {
-							break;
-						}
-					}
-				}
-			}
+    let startTagCount = 1;
+    let c = startRow + 1;
+    const cLen = editor.getLineCount();
+    for (; c<cLen; ++c) {
+      const line = editor.lineTextForBufferRow(c).trim();
+      if (editor.isBufferRowCommented(c)) {
+        if (line.replace(CustomFolds.commentChars,'').trim().startsWith(CustomFolds.prefix)) {
+          ++startTagCount;
+        } else if (line.replace(CustomFolds.commentChars,'').trim().startsWith(CustomFolds.postfix)) {
+          if (--startTagCount === 0) {
+            break;
+          }
+        }
+      }
+    }
 
-			if (c === cLen) {
-				atom.notifications.addWarning(`No end marker found for folding tag that starts on line ${startRow + 1}.`);
-			} else {
-				result = c;
-			}
+    if (c === cLen) {
+      atom.notifications.addWarning(`No end marker found for folding tag that starts on line ${startRow + 1}.`);
+    } else {
+      result = c;
+    }
 
-			return result;
-		},
+    return result;
+  },
 
-		_updateHighlights(editor) {
-			if (!editor.isAlive()) {
-				return;
-			}
-			CustomFolds.commentChars = atom.config.get('editor.commentStart', {scope: editor.getRootScopeDescriptor()})
-			let markers = CustomFolds.editorIdToMarkers[editor.id];
-			markers.forEach((m) => m.destroy());
+  _updateHighlights(editor) {
+    if (!editor.isAlive()) {
+      return;
+    }
 
-			if (!CustomFolds.areRegionsHighlighted) {
-				return;
-			}
+    CustomFolds.commentChars = atom.config.get('editor.commentStart', {scope: editor.getRootScopeDescriptor()});
 
-			for (let c=0, cLen=editor.getLineCount(); c<cLen; ++c) {
-				const line = editor.lineTextForBufferRow(c).trim();
+    let markers = CustomFolds.editorIdToMarkers[editor.id];
+    markers.forEach((m) => m.destroy());
 
-				let cls;
-				if (editor.isBufferRowCommented(c)) {
-					if (line.replace(CustomFolds.commentChars,'').trim().startsWith(CustomFolds.prefix)) {
-						cls = 'custom-folds-start';
-					} else if (line.replace(CustomFolds.commentChars,'').trim().startsWith(CustomFolds.postfix)) {
-						cls = 'custom-folds-stop';
-					}
-				}
+    if (!CustomFolds.areRegionsHighlighted) {
+      return;
+    }
 
-				if (cls) {
-					let range = [[c,0],[c,0]];
-					let marker = editor.markBufferRange(range);
-					markers.push(marker);
-					editor.decorateMarker(marker, {type: 'line', class: cls});
-				}
-			}
-		},
+    for (let c=0, cLen=editor.getLineCount(); c<cLen; ++c) {
+      const line = editor.lineTextForBufferRow(c).trim();
 
-		_updateHighlightsAcrossEditors() {
-			CustomFolds.editors.forEach(CustomFolds._updateHighlights);
-		}
-		// </editor-fold> helpers
-	};
+      let cls;
+
+      if (line.replace(CustomFolds.commentChars,'').trim().startsWith(CustomFolds.prefix)) {
+        cls = 'custom-folds-start';
+      } else if (line.replace(CustomFolds.commentChars,'').trim().startsWith(CustomFolds.postfix)) {
+        cls = 'custom-folds-stop';
+      }
+
+      if (cls) {
+        let range = [[c,0],[c,0]];
+        let marker = editor.markBufferRange(range);
+        markers.push(marker);
+        editor.decorateMarker(marker, {type: 'line', class: cls});
+      }
+    }
+  },
+
+  _updateHighlightsAcrossEditors() {
+    CustomFolds.editors.forEach(CustomFolds._updateHighlights);
+  }
+  // </editor-fold> helpers
+};

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "custom-folds",
   "main": "./lib/index.js",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "description": "Define custom tags for defining foldable blocks of code.",
   "keywords": [
     "fold",

--- a/styles/custom-folds.less
+++ b/styles/custom-folds.less
@@ -6,8 +6,9 @@
 
 atom-text-editor::shadow {
 	.custom-folds-start {
-		.source {
+		.source, .text {
 			// > span:not(.leading):not(.leading-whitespace):not(.whitespace),
+			.comment.block,
 			.comment.definition,
 			.comment.line {
 				color: @text-color-info;
@@ -17,8 +18,9 @@ atom-text-editor::shadow {
 	}
 
 	.custom-folds-stop {
-		.source {
+		.source, .text {
 			// > span:not(.leading):not(.leading-whitespace):not(.whitespace),
+			.comment.block,
 			.comment.definition,
 			.comment.line {
 				color: @text-color-info;


### PR DESCRIPTION
Plugin no longer needs a comment in the "Beginning of foldable region" and "End of foldable region" config fields.
Comments will be pulled from the Root Scope Descriptor's editor.commentStart property.

This allows for use in all languages which have defined commentStart properties in Atoms Grammar definitions