### PR TITLE
Fix folding icon not autohiding

### DIFF
--- a/styles/custom-folds.less
+++ b/styles/custom-folds.less
@@ -37,7 +37,13 @@ atom-text-editor::shadow {
 		}
 	}
 
-	.gutter .line-number.custom-folds-start .icon-right {
-	  visibility: visible;
+	.gutter:hover {
+		.line-number.custom-folds-start .icon-right {
+			visibility: visible;
+
+			&:hover {
+				opacity: 1;
+			}
+		}
 	}
 }


### PR DESCRIPTION
I copied the behaviour from [atom](https://github.com/atom/atom/blob/53aaf0f3d0c0186afe2c5c9112d66ce742369ef2/static/text-editor-shadow.less#L54) so custom-folds blend in with the other fold icons