### PR TITLE
check if editor is not undefined before executing

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -216,6 +216,7 @@ module.exports = {
 	// <editor-fold> RESPONDERS ************************************************
 	foldTopLevel() {
 		const options = CustomFolds._getOptions();
+		if(options.editor==undefined)return;
 
 		for (let c=0, cLen=options.editor.getLineCount(); c<cLen; ++c) {
 			const line = options.editor.lineTextForBufferRow(c).trim();
@@ -239,6 +240,7 @@ module.exports = {
 
 	foldAll() {
 		const { editor, commentChars, areCommentsRequired, prefixes, postfixes } = CustomFolds._getOptions();
+		if(editor==undefined) return;
 
 		let startPrefixStack = [];
 		for (let c=0, cLen=editor.getLineCount(); c<cLen; ++c) {
@@ -270,6 +272,7 @@ module.exports = {
 
 	unfoldAll() {
 		const { editor, commentChars, areCommentsRequired, prefixes } = CustomFolds._getOptions();
+		if(editor==undefined) return;
 
 		for (let c=0, cLen=editor.getLineCount(); c<cLen; ++c) {
 			const line = editor.lineTextForBufferRow(c).trim();
@@ -289,6 +292,7 @@ module.exports = {
 	// TODO: do this for each cursor
 	foldHere() {
 		const options = CustomFolds._getOptions();
+		if(options.editor==undefined) return;
 
 		const row = CustomFolds._rowOfStartTag(options, options.editor.getCursorBufferPosition().row);
 		if (row >= 0) {
@@ -300,6 +304,7 @@ module.exports = {
 		let result = false;
 
 		options = options || CustomFolds._getOptions();
+		if(options.editor==undefined) return;
 
 		row = +row;  // Ensure row is a number
 		const line = options.editor.lineTextForBufferRow(row).trim();
@@ -332,6 +337,7 @@ module.exports = {
 
 	toggleFold() {
 		const options = CustomFolds._getOptions();
+		if(options.editor==undefined) return;
 		const row = options.editor.getCursorBufferPosition().row;
 
 		if (options.editor.isFoldedAtBufferRow(row)) {


### PR DESCRIPTION
The package fails on `atom.workspace.getActiveTextEditor()` being undefined.
I've added an extra check to see whether or not the function returns undefined